### PR TITLE
✨ better handling of tiplanet commands

### DIFF
--- a/src/bonfire.py
+++ b/src/bonfire.py
@@ -21,7 +21,7 @@ class bonfire:
 			except:
 				raise("error while updating chat")
 
-			if chat_id != None:
+			if chat_id != None and not message.content.startswith('/'):
 				self.chat.deletionQueue[self.chat.deletionQueueIndex] = (int(chat_id), message.id)
 				self.chat.deletionQueueIndex = (self.chat.deletionQueueIndex + 1) % len(self.chat.deletionQueue)
 

--- a/src/parser.py
+++ b/src/parser.py
@@ -70,6 +70,9 @@ class Parser:
 	def parse_bbcode2markdown(self, msg, id):
 		msg = html.unescape(msg)
 
+		if msg.startswith('/privmsgto '):
+			return None
+
 		if msg.startswith('/privmsg '):
 			msg = msg[9:]
 

--- a/src/tiplanet.py
+++ b/src/tiplanet.py
@@ -145,8 +145,11 @@ class tiplanet:
 
 		privMsgSuffix = ' (murmure)' if message['content'].startswith('/privmsg ') else ''
 
+		msg = self.parser.parse_bbcode2markdown(message["content"], int(message["userId"]))
+		if msg == None: return
+
 		ds_msg = self.webhook.send(
-			self.parser.parse_bbcode2markdown(message["content"], int(message["userId"])),
+			msg,
 			wait=True, # so we can get the ds_msg
 			avatar_url=f"https://tiplanet.org/forum/avatar.php?id={message['userId']}",
 			username=f'{self.fullconfig.DEVPREFIX}{message["userName"]}{privMsgSuffix}{roleSuffix}',


### PR DESCRIPTION
Some commands generate a message from TI-Bot (/roll).
Others generate a message (or several) from the user, but that message isn't the one sent by the user (/topic or /msg).
This message should come back from tiplanet to discord instead of being considered "already present on discord because that's where the command came from".

Closes #57 by making /privmsg come back and ignoring the now useless /privmsgto.