### PR TITLE
💄 compress login/logout messages even more

### DIFF
--- a/src/tiplanet.py
+++ b/src/tiplanet.py
@@ -143,12 +143,22 @@ class tiplanet:
 
 	async def postDiscordMessage(self, message, bot):
 		if (message["content"].split(' ')[0] in ['/login', '/logout']) and self.config.sendConnections:
-			newInfo = self.parser.parse_basic(message["content"]).replace('/login', '📥').replace('/logout', '📤')
+			msg = message["content"]
+			if msg.startswith('/login'):
+				emoji = '📥'
+			if msg.startswith('/logout'):
+				emoji = '⏰' if msg.endswith(' Timeout') else '📤'
+			pseudo = self.parser.parse_basic(msg.replace('/login ', '').replace('/logout ', '').replace(' Timeout', ''))
 			if self.connectionMsg == None:
 				channel = await bot.fetch_channel(self.fullconfig.SHOUTBOX.channel)
-				self.connectionMsg = await channel.send(newInfo)
+				self.connectionMsg = await channel.send(f'{pseudo} {emoji}')
 			else:
-				await self.connectionMsg.edit(content=f'{self.connectionMsg.content}, {newInfo}')
+				content = self.connectionMsg.content
+				if content.rstrip('📥📤⏰ ').endswith(pseudo.strip()):
+					content = f'{content}{emoji}'
+				else:
+					content = f'{content}, {pseudo} {emoji}'
+				await self.connectionMsg.edit(content=content)
 			return
 
 		role = message["userRole"]

--- a/src/tiplanet.py
+++ b/src/tiplanet.py
@@ -151,13 +151,13 @@ class tiplanet:
 			pseudo = self.parser.parse_basic(msg.replace('/login ', '').replace('/logout ', '').replace(' Timeout', ''))
 			if self.connectionMsg == None:
 				channel = await bot.fetch_channel(self.fullconfig.SHOUTBOX.channel)
-				self.connectionMsg = await channel.send(f'{pseudo} {emoji}')
+				self.connectionMsg = await channel.send(f'{emoji} {pseudo}')
 			else:
-				content = self.connectionMsg.content
-				if content.rstrip('📥📤⏰ ').endswith(pseudo.strip()):
-					content = f'{content}{emoji}'
+				content = self.connectionMsg.content.rstrip()
+				if content.endswith(pseudo.strip()):
+					content = f'{content[:-len(pseudo)-1]}{emoji} {pseudo}'
 				else:
-					content = f'{content}, {pseudo} {emoji}'
+					content = f'{content}, {emoji} {pseudo}'
 				await self.connectionMsg.edit(content=content)
 			return
 


### PR DESCRIPTION
Changes this
📥 redgl0w, 📤 Lil_Nas_X3009, 📤 noelnadal Timeout, 📤 Ti64CLi++ Timeout, 📤 Shadow17 Timeout, 📤 ascpial Timeout, 📥 ascpial, 📤 ascpial, 📥 ascpial, 📤 ascpial Timeout, 📥 ascpial, 📤 ascpial Timeout, 📥 ascpial, 📥 233, 📤 ascpial, 📥 ascpial, 📤 ascpial Timeout, 📥 ascpial, 📤 ascpial Timeout, 📥 ascpial

into this
redgl0w 📥, Lil_Nas_X3009 📤, noelnadal ⏰, Ti64CLi++ ⏰, Shadow17 ⏰, ascpial ⏰📥📤📥⏰📥⏰📥, 233 📥, ascpial 📤📥⏰📥⏰📥

Basically, 
- use alarm clock instead of outbox tray + Timeout for a timeout
- don't repeat username if it's the same

Warning, emojis are on the right side of the username in the new code, not the left side. If it is a problem, I can probably change that.